### PR TITLE
RES-818: Add data validation option

### DIFF
--- a/htmresearch/frameworks/pytorch/dataset_utils.py
+++ b/htmresearch/frameworks/pytorch/dataset_utils.py
@@ -1,0 +1,40 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+import numpy as np
+import torch
+
+def createValidationDataSampler(dataset, ratio):
+  """
+  Create `torch.utils.data.Sampler`s used to split the dataset into 2 ramdom
+  sampled subsets. The first should used for training and the second for
+  validation.
+
+  :param dataset: A valid torch.utils.data.Dataset (i.e. torchvision.datasets.MNIST)
+  :param ratio: The percentage of the dataset to be used for training. The
+                remaining (1-ratio)% will be used for validation
+  :return: tuple with 2 torch.utils.data.Sampler. (train, validate)
+  """
+  indices = np.random.permutation(len(dataset))
+  training_count = int(len(indices) * ratio)
+  train = torch.utils.data.SubsetRandomSampler(indices=indices[:training_count])
+  validate = torch.utils.data.SubsetRandomSampler(indices=indices[training_count:])
+  return (train, validate)
+

--- a/htmresearch/frameworks/pytorch/mnist_sparse_experiment.py
+++ b/htmresearch/frameworks/pytorch/mnist_sparse_experiment.py
@@ -35,6 +35,7 @@ from htmresearch.frameworks.pytorch.image_transforms import RandomNoise
 from htmresearch.frameworks.pytorch.sparse_mnist_net import SparseMNISTNet
 from htmresearch.frameworks.pytorch.sparse_mnist_cnn import SparseMNISTCNN
 from htmresearch.frameworks.pytorch.duty_cycle_metrics import plotDutyCycles
+from htmresearch.frameworks.pytorch.dataset_utils import createValidationDataSampler
 
 
 class MNISTSparseExperiment(PyExperimentSuite):
@@ -82,10 +83,8 @@ class MNISTSparseExperiment(PyExperimentSuite):
     # where X can be tuned via the "validation" parameter
     validation = params.get("validation", 50000.0 / 60000.0)
     if validation < 1.0:
-      indices = np.random.permutation(len(train_dataset))
-      training_count = int(len(indices) * validation)
-      self.train_sampler = torch.utils.data.SubsetRandomSampler(indices=indices[:training_count])
-      self.validation_sampler = torch.utils.data.SubsetRandomSampler(indices=indices[training_count:])
+      self.train_sampler, self.validation_sampler = createValidationDataSampler(
+        train_dataset, validation)
 
       self.train_loader = torch.utils.data.DataLoader(train_dataset,
                                                       batch_size=params["batch_size"],

--- a/projects/sdr_paper/pytorch_experiments/experiments.cfg
+++ b/projects/sdr_paper/pytorch_experiments/experiments.cfg
@@ -22,6 +22,10 @@ log_interval = 1000         # how many minibatches to wait before logging
 create_plots = False
 test_noise_every_epoch = True # If False, will only test noise at end
 
+; validation dataset ratio. Train on X%, validate on (1-X)%.
+; Set to 1.0 to skip the validation step and use the whole training dataset
+validation = float(50000.0/60000.0)
+
 path = results
 datadir = "data"
 


### PR DESCRIPTION
Added new `validation` parameter used to configure the portion of the training dataset to be used for validation. A new `validation` field will be added with the test error and  noise test results
Here is a sample output when validation is enabled:
```
   {
    "elapsedTime": 11.260179042816162,
    "validation": {
      "num_correct": 9153,
      "test_loss": 0.2917319641113281,
      "entropy": 31.192007064819336,
      "testerror": 91.53
    },
    "entropy": 31.192007064819336,
    "num_correct": 9179,
    "learningRate": 0.04,
    "test_loss": 0.2706499237060547,
    "iteration": 0,
    "testerror": 91.79
  },
  {
    "0.0": {
      "num_correct": 9435,
      "test_loss": 0.19246396942138672,
      "entropy": 31.869386672973633,
      "testerror": 94.35
    },
    "0.25": {
      "num_correct": 7053,
      "test_loss": 1.0351202758789062,
      "entropy": 31.869386672973633,
      "testerror": 70.53
    },
    ...
    "validation": {
      "0.0": {
        "num_correct": 9327,
        "test_loss": 0.21947733612060547,
        "entropy": 31.869386672973633,
        "testerror": 93.27
      },
      "0.25": {
        "num_correct": 6943,
        "test_loss": 1.0943427612304688,
        "entropy": 31.869386672973633,
        "testerror": 69.43
      },
    ...
}

```

Setting this parameter to 1 disable the validation step and train on the whole dataset.